### PR TITLE
add "test" keymap. enable LTO for size

### DIFF
--- a/qmk_firmware/keyboards/willow/pecoe/keymaps/test/config.h
+++ b/qmk_firmware/keyboards/willow/pecoe/keymaps/test/config.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#define TAP_CODE_DELAY 10
+
+// Disable some QMK Features for test.
+#define NO_ACTION_ONESHOT
+#define NO_ACTION_MACRO
+#define NO_ACTION_FUNCTION

--- a/qmk_firmware/keyboards/willow/pecoe/keymaps/test/keymap.c
+++ b/qmk_firmware/keyboards/willow/pecoe/keymaps/test/keymap.c
@@ -1,0 +1,80 @@
+/* Copyright 2021 hanachi-ap
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+// Defines names for use in layer keycodes and the keymap
+enum layer_names {
+    _QWERTY,
+};
+
+// Defines the keycodes used by our macros in process_record_user
+enum custom_keycodes {
+    SW_ENCODER = SAFE_RANGE
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+[_QWERTY]=LAYOUT(   //QWERTY (for test)
+			KC_ESC	,	KC_Q	,	KC_W	,	KC_E	,	KC_R	,	KC_T	,							KC_Y	,	KC_U	,	KC_I	,	KC_O	,	KC_P	,	KC_LBRC	,	KC_RBRC	,
+			KC_TAB	,	KC_A	,	KC_S	,	KC_D	,	KC_F	,	KC_G	,							KC_H	,	KC_J	,	KC_K	,	KC_L	,	KC_SCLN	,	KC_MINS	,	KC_ENT	,
+			KC_LSFT	,	KC_Z	,	KC_X	,	KC_C	,	KC_V	,	KC_B	,	KC_DEL	,			KC_RGUI	,	KC_N	,	KC_M	,	KC_COMM	,	KC_DOT	,	KC_SLSH	,	KC_RSFT	,
+	SW_ENCODER	,					        KC_LEFT	,	KC_RIGHT,	KC_SPC	,	KC_LCTL	,	KC_LALT,	KC_ENT	,	KC_BSPC	,	KC_DOWN	,	KC_UP
+)
+};
+
+static int encoder_mode = 0;
+
+void keyboard_post_init_user(void) {
+    // Turn on RGBLIGHT with test mode, without writing EEPROM.
+    rgblight_enable_noeeprom();
+    rgblight_mode_noeeprom(RGBLIGHT_MODE_RGB_TEST);
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case SW_ENCODER:
+            if (record->event.pressed) {
+                if (encoder_mode == 0) {
+                    encoder_mode = 1;
+                    rgblight_disable_noeeprom();
+                } else {
+                    encoder_mode = 0;
+                    rgblight_enable_noeeprom();
+                }
+            }
+            return false;
+    }
+    return true;
+}
+
+void encoder_update_user(uint8_t index, bool clockwise) {
+    if (encoder_mode == 0) {
+        if (clockwise) {
+            tap_code(KC_PGDN);
+        } else {
+            tap_code(KC_PGUP);
+        }
+    } else {
+        if (clockwise) {
+            tap_code(KC_END);
+        } else {
+            tap_code(KC_HOME);
+        }
+    }
+}
+
+void encoder_update_kb(uint8_t index, bool clockwise) {
+    encoder_update_user(index, clockwise);
+}

--- a/qmk_firmware/keyboards/willow/pecoe/keymaps/test/readme.md
+++ b/qmk_firmware/keyboards/willow/pecoe/keymaps/test/readme.md
@@ -1,0 +1,25 @@
+# The test keymap for willow/pecoe
+
+This test firmware is only for left-sided rotary encoder (Side-A is surface)
+for now.
+
+It starts RGB light with test pattern.  Test pattern means all LEDs will light
+and change those color: red, green, blue at constant interval.
+
+Test keymap is very simple to test keys.  No layersk, no tappings or so.  You
+can test all keys (and a rotary encoder also) with
+<https://config.qmk.fm/#/test/> easily.
+
+## Rotary Encoder
+
+Rotation of a rotary encoder is parsed as `Page Up` (counter clockwise) or
+`Page Down` (clockwise) keys as normal.
+
+Pressing switch of rotary encoder changes hidden-internal mode to parse
+rotation of rotary encoder.  When changed the mode, rotation is parsed as
+`Home` (counter clockwise) or `End` (clockwise).  Then press a switch again to
+return to the original parsing mode.
+
+Parsing mode is indicated with RGB LEDs.  For normal mode, RGB light will be
+enabled with test pattern.  For alternative mode, RGB light will be disabeld,
+all LEDs are turned off.

--- a/qmk_firmware/keyboards/willow/pecoe/keymaps/test/rules.mk
+++ b/qmk_firmware/keyboards/willow/pecoe/keymaps/test/rules.mk
@@ -1,0 +1,5 @@
+# Except VIA support for test
+VIA_ENABLE = no
+
+# Disable auto shift feature, because it impredes test 
+AUTO_SHIFT_ENABLE = no

--- a/qmk_firmware/keyboards/willow/pecoe/rules.mk
+++ b/qmk_firmware/keyboards/willow/pecoe/rules.mk
@@ -27,3 +27,6 @@ CUSTOM_MATRIX = yes
 
 VIA_ENABLE = yes
 AUTO_SHIFT_ENABLE = yes
+
+# Reduce firmware size: enable Link-Time-Optimization
+LTO_ENABLE = yes


### PR DESCRIPTION
#1 で使ったテスト用のキーマップです。

基本のキーマップはなるべく維持したまま
ビルド時のテストのしやすさを最優先にするためにレイヤー操作やタッピングを排しました。
RGB LEDはテストパターンで点灯させてます。このとき設定はEEPROMに保存していません。
ロータリエンコーダでは、
プッシュスイッチは押すごとにLEDの点灯・消灯を切り替え `encoder_mode` の状態を反映するようにしました。
回転はキー操作として https://config.qmk.fm/#/test で見やすいキー(PageUp, PageDown, Home, End)にマップしました。

あとLTOをキーボードレベルのrules.mkで有効化しました。
VIA有効でギリギリだったサイズに少し余裕ができるので、ファームをいじって遊ぶ余地が増えます。